### PR TITLE
mystats: add 0.1.0 formula

### DIFF
--- a/Formula/mystats.rb
+++ b/Formula/mystats.rb
@@ -1,0 +1,73 @@
+class Mystats < Formula
+  desc "Lightweight Apple Silicon menu bar monitor for macOS"
+  homepage "https://github.com/SeokminHong/mystats"
+  url "https://github.com/SeokminHong/mystats/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "ebb0a54f07f1c6cb23c9c97001821d9b8103d8c5ec40cb924ad229771677f8b3"
+  license "MIT"
+
+  head "https://github.com/SeokminHong/mystats.git", branch: "main"
+
+  depends_on xcode: ["15.0", :build]
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+
+  def install
+    system "swift", "build", "-c", "release", "--disable-sandbox"
+
+    app_bundle = prefix/"mystats.app"
+    app_contents = app_bundle/"Contents"
+    app_macos = app_contents/"MacOS"
+    app_resources = app_contents/"Resources"
+
+    app_macos.install ".build/release/mystats"
+    app_resources.mkpath
+    system "swift", "script/generate_app_icon.swift", (app_resources/"AppIcon.icns").to_s
+
+    (app_contents/"Info.plist").write <<~XML
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+        <key>CFBundleExecutable</key>
+        <string>mystats</string>
+        <key>CFBundleIdentifier</key>
+        <string>com.seokmin.mystats</string>
+        <key>CFBundleName</key>
+        <string>mystats</string>
+        <key>CFBundleDisplayName</key>
+        <string>mystats</string>
+        <key>CFBundleIconFile</key>
+        <string>AppIcon</string>
+        <key>CFBundlePackageType</key>
+        <string>APPL</string>
+        <key>CFBundleShortVersionString</key>
+        <string>#{version}</string>
+        <key>CFBundleVersion</key>
+        <string>1</string>
+        <key>LSMinimumSystemVersion</key>
+        <string>13.0</string>
+        <key>LSUIElement</key>
+        <true/>
+        <key>NSPrincipalClass</key>
+        <string>NSApplication</string>
+      </dict>
+      </plist>
+    XML
+
+    (bin/"mystats").write <<~SH
+      #!/bin/bash
+      if [[ "$1" == "--version" || "$1" == "--help" || "$1" == "-h" ]]; then
+        exec "#{app_macos}/mystats" "$@"
+      fi
+
+      exec /usr/bin/open -n "#{app_bundle}" --args "$@"
+    SH
+    chmod 0755, bin/"mystats"
+  end
+
+  test do
+    assert_match "mystats 0.1.0", shell_output("#{bin}/mystats --version")
+    assert_path_exists prefix/"mystats.app/Contents/MacOS/mystats"
+    assert_path_exists prefix/"mystats.app/Contents/Info.plist"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## formulae
 
 - [fenv](https://github.com/SeokminHong/fenv): direnv alternative for Fish shell.
+- [mystats](https://github.com/SeokminHong/mystats): Apple Silicon menu bar monitor for macOS.
 - [vltl](https://github.com/SeokminHong/vltl): Fix Korean typo on shell for MacOS.
 
 ## Installation
@@ -11,5 +12,5 @@
 $ brew install seokminhong/brew/<formula>
 # OR
 $ brew tap seokminhong/brew
-$ brew install <fomula>
+$ brew install <formula>
 ```


### PR DESCRIPTION
## Summary

- Add the `mystats` Homebrew formula for the `v0.1.0` source release.
- Install a generated `mystats.app` bundle plus a `mystats` launch wrapper.
- Document `mystats` in the tap README and fix the formula placeholder typo.

## Validation

- `brew style Formula/mystats.rb`
- `brew audit --strict --online --formula codex/mystats/mystats`
- `brew install --build-from-source codex/mystats/mystats`
- `brew test codex/mystats/mystats`