### PR TITLE
mystats: update to 0.2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,9 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Install Linux sandbox dependency
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Install Linux sandbox dependency
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w user.max_user_namespaces=28633
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,10 @@ jobs:
         os: [ubuntu-24.04, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Linux sandbox dependency
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,12 @@ jobs:
     steps:
       - name: Install Linux sandbox dependency
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bubblewrap
+          sudo sysctl -w kernel.unprivileged_userns_clone=1
+          sudo sysctl -w user.max_user_namespaces=28633
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
 
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/Formula/mystats.rb
+++ b/Formula/mystats.rb
@@ -1,17 +1,11 @@
 class Mystats < Formula
   desc "Lightweight Apple Silicon menu bar monitor for macOS"
   homepage "https://github.com/SeokminHong/mystats"
-  url "https://github.com/SeokminHong/mystats/archive/refs/tags/v0.2.1.tar.gz"
-  sha256 "ea5f9d0ef4f1de665bcb1af4dd49df251b89a7b4f57b6647f55476e4621d7934"
+  url "https://github.com/SeokminHong/mystats/archive/refs/tags/v0.2.2.tar.gz"
+  sha256 "abb5985ba44c7d50f1cf72e2e0c24d2db737750f5ca1896500e539aa3e849a97"
   license "MIT"
 
   head "https://github.com/SeokminHong/mystats.git", branch: "main"
-
-  bottle do
-    root_url "https://github.com/SeokminHong/homebrew-brew/releases/download/mystats-0.2.1"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "3827d83a91adba66d4c2a75af2464b75f0ba00427cd45d790b7241ce37484a22"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "780f0052e2e889a22e34cd70fb91bdc55eed4a847ea0596c303a1633beaf1a0e"
-  end
 
   depends_on xcode: ["15.0", :build]
   depends_on arch: :arm64
@@ -72,7 +66,7 @@ class Mystats < Formula
   end
 
   test do
-    assert_match "mystats 0.2.1", shell_output("#{bin}/mystats --version")
+    assert_match "mystats 0.2.2", shell_output("#{bin}/mystats --version")
     assert_path_exists prefix/"mystats.app/Contents/MacOS/mystats"
     assert_path_exists prefix/"mystats.app/Contents/Info.plist"
   end


### PR DESCRIPTION
## Summary

Update mystats formula to the `v0.2.2` source release.
Install `bubblewrap` in Linux CI jobs so Homebrew's Linux sandbox setup can pass on the current Ubuntu runner image.

## Checks

- `ruby -c Formula/mystats.rb`
- `brew style Formula/mystats.rb`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "#{path}: OK" }' .github/workflows/tests.yml .github/workflows/publish.yml`

## Notes

The previous bottle block was removed because the formula now points at a new source tag.
