### PR TITLE
ci(brew): verify formulae on Intel macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15, macos-26]
+        os: [ubuntu-24.04, macos-15, macos-26, macos-15-intel]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Linux sandbox dependency


### PR DESCRIPTION
## Summary

Formula changes need Intel macOS coverage before bottle publication.

- add `macos-15-intel` to the `brew test-bot` matrix

## Test

- GitHub Actions workflow syntax reviewed
