### PR TITLE
kfind: use pkgshare

### DIFF
--- a/Formula/kfind.rb
+++ b/Formula/kfind.rb
@@ -30,7 +30,7 @@ class Kfind < Formula
     system "cargo", "install", *std_cargo_args(path: "crates/kfind-cli")
 
     resource("full-pos-lexicon").stage do
-      (share/"kfind").install "lexicon.bin", "MANIFEST.toml"
+      pkgshare.install "lexicon.bin", "MANIFEST.toml"
       (share/"doc/kfind/LICENSES").install "LICENSES/mecab-ko-dic-COPYING"
     end
 


### PR DESCRIPTION
## Summary

Keep the kfind data install path idiomatic and strict-audit clean.

- use `pkgshare` for the existing `share/kfind` destination

## Test

- `ruby -c Formula/kfind.rb`
- `brew style Formula/kfind.rb`
- `brew audit --strict seokminhong/brew/kfind`
- `brew test seokminhong/brew/kfind`

Apply `pr-pull` only after every `brew test-bot` job passes.
