### PR TITLE
kfind 1.0.0-rc.1

### DIFF
--- a/Formula/kfind.rb
+++ b/Formula/kfind.rb
@@ -1,34 +1,25 @@
 class Kfind < Formula
   desc "Fast Korean lemma and inflection search for code and documents"
   homepage "https://github.com/SeokminHong/kfind"
-  url "https://github.com/SeokminHong/kfind/releases/download/v0.3.0-rc.3/kfind-0.3.0-rc.3.tar.gz"
-  sha256 "82a576245e95619fcbb15faeb634413186ed238dc63521c37a4ac5cc7f91a4e8"
-  license "MIT"
-
-  head "https://github.com/SeokminHong/kfind.git", branch: "main"
-
-  bottle do
-    root_url "https://github.com/SeokminHong/homebrew-brew/releases/download/kfind-0.3.0-rc.3"
-    sha256 cellar: :any_skip_relocation, arm64_tahoe:   "c1c7fc4a2f365939cf97b03ba6b8083672df9e782429cb746a76651383569f4e"
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "074a50eee0a8b3a2c0d24b174c91e46b9a0ea60ea7bcfbabcd6bf2165f803c7c"
-    sha256 cellar: :any,                 x86_64_linux:  "21534bed9e0eb3c4b78f8f0246340ade366d401cc400aeba0003b7684a65f457"
-  end
+  url "https://github.com/SeokminHong/kfind/releases/download/v1.0.0-rc.1/kfind-1.0.0-rc.1.tar.gz"
+  sha256 "b56069d95fead87a37e94879118107d33b9a672f5a16774adbbc865a79be29f0"
+  license :cannot_represent
 
   depends_on "rustup" => :build
 
   resource "full-pos-lexicon" do
-    url "https://github.com/SeokminHong/kfind/releases/download/v0.3.0-rc.3/kfind-full-pos-0.3.0-rc.3.tar.gz"
+    url "https://github.com/SeokminHong/kfind/releases/download/v1.0.0-rc.1/kfind-full-pos-1.0.0-rc.1.tar.gz"
     sha256 "937e27b2068dd8aa38e06af264bea726c9d6b2d8b66f2135a6445f84a526a388"
   end
 
   resource "component-resource" do
-    url "https://github.com/SeokminHong/kfind/releases/download/v0.3.0-rc.3/kfind-component-0.3.0-rc.3.tar.gz"
-    sha256 "4f9897fdc5ccb031bb1c370b119b3be6b422510dffb13d55079f317fafd1ac47"
+    url "https://github.com/SeokminHong/kfind/releases/download/v1.0.0-rc.1/kfind-component-1.0.0-rc.1.tar.gz"
+    sha256 "d0f980d2523ed67cafdc3e6ffd45f50b81a38666732eb0d8c3f0d56e6123d01d"
   end
 
   resource "distribution-assets" do
-    url "https://github.com/SeokminHong/kfind/releases/download/v0.3.0-rc.3/kfind-assets-0.3.0-rc.3.tar.gz"
-    sha256 "e662dd950c8f2aa16bd499597ae376b2b28cc12c2fca6a51bad073d70a5a08f9"
+    url "https://github.com/SeokminHong/kfind/releases/download/v1.0.0-rc.1/kfind-assets-1.0.0-rc.1.tar.gz"
+    sha256 "919d18acf7402dce4f6fe2e2e7044ae97f1fdfd4736a1468b636207e225a5251"
   end
 
   def install
@@ -60,6 +51,10 @@ class Kfind < Formula
     (share/"doc/kfind/LICENSES").install Dir["LICENSE*"]
   end
 
+  def post_install
+    system bin/"kfind", "--check-data", "--data-dir", pkgshare
+  end
+
   test do
     sample = testpath/"sample.txt"
     sample.write("아주 예쁜 길을 걸어 갔다.\n")
@@ -79,6 +74,9 @@ class Kfind < Formula
     component.write("사용자권한을 확인했다.\n대학교를 방문했다.\n")
     assert_match "사용자권한", shell_output("#{bin}/kfind 권한 #{component}")
     assert_empty shell_output("#{bin}/kfind 학교 #{component}", 1)
+    data_check = shell_output("#{bin}/kfind --check-data --json --data-dir #{pkgshare}")
+    assert_match '"status":"ok"', data_check
+    assert_match '"resource_version":"1.0.0-rc.1"', data_check
 
     assert_predicate pkgshare/"skills/kfind/SKILL.md", :file?
     assert_predicate pkgshare/"predicates.enriched.tsv", :file?


### PR DESCRIPTION
## 요약

- kfind 1.0.0-rc.1을 배포합니다.
- full-POS, morphology component, CLI 배포 asset을 설치합니다.

## 검증

- `ruby -c Formula/kfind.rb`
- `brew style Formula/kfind.rb`
