### PR TITLE
fix: Homebrew 테스트를 현재 제품 계약에 맞춘다

### DIFF
--- a/Formula/kfind.rb
+++ b/Formula/kfind.rb
@@ -73,7 +73,7 @@ class Kfind < Formula
     component = testpath/"component.txt"
     component.write("사용자권한을 확인했다.\n대학교를 방문했다.\n")
     assert_match "사용자권한", shell_output("#{bin}/kfind 권한 #{component}")
-    assert_empty shell_output("#{bin}/kfind 학교 #{component}", 1)
+    assert_match "대학교", shell_output("#{bin}/kfind 학교 #{component}")
     data_check = shell_output("#{bin}/kfind --check-data --json --data-dir #{pkgshare}")
     assert_match '"status":"ok"', data_check
     assert_match '"resource_version":"1.0.0-rc.1"', data_check


### PR DESCRIPTION
## 변경 사항

- kfind 1.0.0-rc.1의 component 검색 계약에 맞춰 대학교에서 학교가 검색되는지 검증합니다.

## 검증

- ruby -c Formula/kfind.rb
- brew style Formula/kfind.rb