### PR TITLE
test: Homebrew component 출력을 전체 문장으로 검증한다

### DIFF
--- a/Formula/kfind.rb
+++ b/Formula/kfind.rb
@@ -73,7 +73,7 @@ class Kfind < Formula
     component = testpath/"component.txt"
     component.write("사용자권한을 확인했다.\n대학교를 방문했다.\n")
     assert_match "사용자권한", shell_output("#{bin}/kfind 권한 #{component}")
-    assert_match "대학교", shell_output("#{bin}/kfind 학교 #{component}")
+    assert_match "대학교를 방문했다.", shell_output("#{bin}/kfind 학교 #{component}")
     data_check = shell_output("#{bin}/kfind --check-data --json --data-dir #{pkgshare}")
     assert_match '"status":"ok"', data_check
     assert_match '"resource_version":"1.0.0-rc.1"', data_check


### PR DESCRIPTION
## 변경 사항

- 학교 component 검색의 전체 출력 문장을 검증합니다.
- test-bot 통과 후 pr-pull로 1.0.0-rc.1 bottle을 게시합니다.

## 검증

- ruby -c Formula/kfind.rb
- brew style Formula/kfind.rb